### PR TITLE
This might fix the problem for CiviCRM 4.7.

### DIFF
--- a/l10nupdate.php
+++ b/l10nupdate.php
@@ -76,7 +76,7 @@ function _l10nupdate_fetch($locales = '') {
   $config = CRM_Core_Config::singleton();
 
   // Check that the l10n directory is configured, exists, and is writable
-  $l10n = $config->gettextResourceDir;
+  $l10n = CRM_Core_I18n::getResourceDir();
   if (empty($l10n)) {
     CRM_Core_Session::setStatus(
       ts('Your localization directory is not configured.', array('domain' => L10N_UPDATE_DOMAIN)),


### PR DESCRIPTION
Refs #3. This might work. The error message is gone, but I did not extensively test this, because it seems that the transifex project [does not contain the new strings for CiviCRM 4.7](https://civicrm.stackexchange.com/questions/10108/how-to-fix-translations-in-civicrm-4-7).
