### PR TITLE
Allow selection of additional UI languages in single-language mode. Add an API to fetch updated translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-Localization Update
-===================
+# Localization Update
 
 Automated download of translations files for CiviCRM core and extensions.
-
-Once installed, this extension will automatically download translation files for CiviCRM core and extensions when you
-access either the localization settings or extension management screens in CiviCRM administration. The localization
-settings screen will also display all possible languages you can enable in CiviCRM.
 
 This extension optimizes the downloads in terms of frequency and needed files for your current setup.
 
@@ -15,19 +10,25 @@ extension management screen and it will work it's magic.
 This extension was originated during the 2014 CiviCON Sprint in Lake Tahoe. Attending a Sprint is a great way to support
 our community, meet wonderful people, and have loads of fun even if you are not a programmer or implementer.
 
-Requirements
-============
+In "single language mode" this extension allows you to select multiple UI languages even if they are not installed.
+Once selected the extension will automatically download them.
+
+## Requirements
 
 * The hosting server must have php5-curl installed.
 * The civicrm/l10n directory must be writable by the web server,
   as well as the l10n directory of each extension installed.
 These requirements are normally fulfilled in a standard CiviCRM installation.
 
-Support
-=======
+## Usage
 
-Please post support and feature requests for this extension to the "internationalization and localization" forum:
-http://forum.civicrm.org/index.php/board,10.0.html
+Once installed, this extension will automatically download translation files for CiviCRM core and extensions when you
+access either the localization settings or extension management screens in CiviCRM administration. The localization
+settings screen will also display all possible languages you can enable in CiviCRM.
+
+You can manually trigger the update using the API3: `L10nupdate.fetch`
+
+## Support
 
 The latest version of this extension can be found at:
 https://github.com/cividesk/com.cividesk.l10n.update
@@ -35,8 +36,7 @@ https://github.com/cividesk/com.cividesk.l10n.update
 The bug tracker is located at:
 https://github.com/cividesk/com.cividesk.l10n.update/issues
 
-Copyright
-=========
+## Copyright
 
 Copyright (C) 2014 IT Bliss LLC, http://cividesk.com/
 

--- a/api/v3/L10nupdate/Fetch.php
+++ b/api/v3/L10nupdate/Fetch.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws \CiviCRM_API3_Exception
+ */
+function civicrm_api3_l10nupdate_fetch($params) {
+  l10nupdate_fetch();
+  return civicrm_api3_create_success([], $params, 'L10nupdate', 'Fetch');
+}

--- a/api/v3/L10nupdate/Fetch.php
+++ b/api/v3/L10nupdate/Fetch.php
@@ -1,5 +1,20 @@
 <?php
 
+function _civicrm_api3_l10nupdate_fetch_spec(&$params) {
+  $params['locales'] = [
+    'title' => 'Locales',
+    'type' => CRM_Utils_Type::T_STRING,
+    'description' => 'Comma-delimited list of additional languages that need to be fetched',
+    'api.default' => '',
+  ];
+  $params['forceDownload'] = [
+    'title' => 'Force download',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'description' => 'Force download of translation files if we already downloaded an up to date (within the last 1 day) translation.',
+    'api.default' => FALSE,
+  ];
+}
+
 /**
  * @param array $params
  * @return array API result descriptor
@@ -8,6 +23,6 @@
  * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_l10nupdate_fetch($params) {
-  l10nupdate_fetch();
-  return civicrm_api3_create_success([], $params, 'L10nupdate', 'Fetch');
+  $downloaded = l10nupdate_fetch($params['locales'], $params['forceDownload']);
+  return civicrm_api3_create_success($downloaded, $params, 'L10nupdate', 'Fetch');
 }

--- a/info.xml
+++ b/info.xml
@@ -6,24 +6,24 @@
     <urls>
         <url desc="Main Extension Page">https://github.com/cividesk/com.cividesk.l10n.autofetch</url>
         <url desc="Documentation">https://github.com/cividesk/com.cividesk.l10n.autofetch</url>
-        <url desc="Support">http://forum.civicrm.org/index.php/board,10.0.html</url>
+        <url desc="Support">https://github.com/cividesk/com.cividesk.l10n.update/issues</url>
     </urls>
     <license>AGPL v3</license>
     <maintainer>
         <author>Nicolas Ganivet (cividesk)</author>
         <email>support@cividesk.com</email>
     </maintainer>
-    <releaseDate>2014-05-02</releaseDate>
-    <version>1.0-beta</version>
+    <releaseDate>2020-04-05</releaseDate>
+    <version>1.1</version>
     <compatibility>
-        <ver>4.2</ver>
-        <ver>4.3</ver>
-        <ver>4.4</ver>
-        <ver>4.5</ver>
+        <ver>5.19</ver>
     </compatibility>
     <comments>
         Once installed, this extension will automatically download translation files for CiviCRM core and extensions when you
         access either the localization settings or extension management screens in CiviCRM administration. The localization
         settings screen will also display all possible languages you can enable in CiviCRM.
     </comments>
+  <civix>
+    <namespace>CRM/L10nupdate</namespace>
+  </civix>
 </extension>

--- a/l10nupdate.civix.php
+++ b/l10nupdate.civix.php
@@ -1,0 +1,477 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_L10nupdate_ExtensionUtil {
+  const SHORT_NAME = "l10nupdate";
+  const LONG_NAME = "com.cividesk.l10n.update";
+  const CLASS_PREFIX = "CRM_L10nupdate";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_L10nupdate_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _l10nupdate_civix_civicrm_config(&$config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $template =& CRM_Core_Smarty::singleton();
+
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extDir = $extRoot . 'templates';
+
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
+  }
+
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_xmlMenu().
+ *
+ * @param $files array(string)
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
+ */
+function _l10nupdate_civix_civicrm_xmlMenu(&$files) {
+  foreach (_l10nupdate_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+    $files[] = $file;
+  }
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _l10nupdate_civix_civicrm_install() {
+  _l10nupdate_civix_civicrm_config();
+  if ($upgrader = _l10nupdate_civix_upgrader()) {
+    $upgrader->onInstall();
+  }
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _l10nupdate_civix_civicrm_postInstall() {
+  _l10nupdate_civix_civicrm_config();
+  if ($upgrader = _l10nupdate_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function _l10nupdate_civix_civicrm_uninstall() {
+  _l10nupdate_civix_civicrm_config();
+  if ($upgrader = _l10nupdate_civix_upgrader()) {
+    $upgrader->onUninstall();
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _l10nupdate_civix_civicrm_enable() {
+  _l10nupdate_civix_civicrm_config();
+  if ($upgrader = _l10nupdate_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
+ */
+function _l10nupdate_civix_civicrm_disable() {
+  _l10nupdate_civix_civicrm_config();
+  if ($upgrader = _l10nupdate_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_upgrade().
+ *
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
+ *
+ * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *                for 'enqueue', returns void
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function _l10nupdate_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  if ($upgrader = _l10nupdate_civix_upgrader()) {
+    return $upgrader->onUpgrade($op, $queue);
+  }
+}
+
+/**
+ * @return CRM_L10nupdate_Upgrader
+ */
+function _l10nupdate_civix_upgrader() {
+  if (!file_exists(__DIR__ . '/CRM/L10nupdate/Upgrader.php')) {
+    return NULL;
+  }
+  else {
+    return CRM_L10nupdate_Upgrader_Base::instance();
+  }
+}
+
+/**
+ * Search directory tree for files which match a glob pattern.
+ *
+ * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
+ * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ *
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array(string)
+ */
+function _l10nupdate_civix_find_files($dir, $pattern) {
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
+    return CRM_Utils_File::findFiles($dir, $pattern);
+  }
+
+  $todos = [$dir];
+  $result = [];
+  while (!empty($todos)) {
+    $subdir = array_shift($todos);
+    foreach (_l10nupdate_civix_glob("$subdir/$pattern") as $match) {
+      if (!is_dir($match)) {
+        $result[] = $match;
+      }
+    }
+    if ($dh = opendir($subdir)) {
+      while (FALSE !== ($entry = readdir($dh))) {
+        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+        if ($entry{0} == '.') {
+        }
+        elseif (is_dir($path)) {
+          $todos[] = $path;
+        }
+      }
+      closedir($dh);
+    }
+  }
+  return $result;
+}
+/**
+ * (Delegated) Implements hook_civicrm_managed().
+ *
+ * Find any *.mgd.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
+ */
+function _l10nupdate_civix_civicrm_managed(&$entities) {
+  $mgdFiles = _l10nupdate_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
+  foreach ($mgdFiles as $file) {
+    $es = include $file;
+    foreach ($es as $e) {
+      if (empty($e['module'])) {
+        $e['module'] = E::LONG_NAME;
+      }
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
+      $entities[] = $e;
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_caseTypes().
+ *
+ * Find any and return any files matching "xml/case/*.xml"
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
+ */
+function _l10nupdate_civix_civicrm_caseTypes(&$caseTypes) {
+  if (!is_dir(__DIR__ . '/xml/case')) {
+    return;
+  }
+
+  foreach (_l10nupdate_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    $name = preg_replace('/\.xml$/', '', basename($file));
+    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+      throw new CRM_Core_Exception($errorMessage);
+    }
+    $caseTypes[$name] = [
+      'module' => E::LONG_NAME,
+      'name' => $name,
+      'file' => $file,
+    ];
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function _l10nupdate_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _l10nupdate_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = E::LONG_NAME;
+    }
+    $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _l10nupdate_civix_civicrm_themes(&$themes) {
+  $files = _l10nupdate_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
+ * Glob wrapper which is guaranteed to return an array.
+ *
+ * The documentation for glob() says, "On some systems it is impossible to
+ * distinguish between empty match and an error." Anecdotally, the return
+ * result for an empty match is sometimes array() and sometimes FALSE.
+ * This wrapper provides consistency.
+ *
+ * @link http://php.net/glob
+ * @param string $pattern
+ *
+ * @return array, possibly empty
+ */
+function _l10nupdate_civix_glob($pattern) {
+  $result = glob($pattern);
+  return is_array($result) ? $result : [];
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _l10nupdate_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label'      => CRM_Utils_Array::value('name', $item),
+        'active'     => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _l10nupdate_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _l10nupdate_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _l10nupdate_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _l10nupdate_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _l10nupdate_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _l10nupdate_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _l10nupdate_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
+ */
+function _l10nupdate_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+    $metaDataFolders[] = $settingsDir;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+
+function _l10nupdate_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+  ));
+}

--- a/l10nupdate.civix.php
+++ b/l10nupdate.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_L10nupdate_ExtensionUtil {
-  const SHORT_NAME = "l10nupdate";
-  const LONG_NAME = "com.cividesk.l10n.update";
-  const CLASS_PREFIX = "CRM_L10nupdate";
+  const SHORT_NAME = 'l10nupdate';
+  const LONG_NAME = 'com.cividesk.l10n.update';
+  const CLASS_PREFIX = 'CRM_L10nupdate';
 
   /**
    * Translate a string using the extension's domain.
@@ -193,8 +193,9 @@ function _l10nupdate_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
@@ -225,7 +226,7 @@ function _l10nupdate_civix_upgrader() {
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
  *
- * @return array(string)
+ * @return array
  */
 function _l10nupdate_civix_find_files($dir, $pattern) {
   if (is_callable(['CRM_Utils_File', 'findFiles'])) {
@@ -244,7 +245,7 @@ function _l10nupdate_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;
@@ -255,6 +256,7 @@ function _l10nupdate_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
@@ -362,7 +364,7 @@ function _l10nupdate_civix_civicrm_themes(&$themes) {
  * @link http://php.net/glob
  * @param string $pattern
  *
- * @return array, possibly empty
+ * @return array
  */
 function _l10nupdate_civix_glob($pattern) {
   $result = glob($pattern);
@@ -470,8 +472,6 @@ function _l10nupdate_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _l10nupdate_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
+  $entityTypes = array_merge($entityTypes, []);
 }


### PR DESCRIPTION
This allows you to select any "available" UI language even if it is not downloaded in single-language mode. For a long time you've been able to do this in single language mode following work by @aydun but if you've not downloaded you can't select the language.

Adds an API function: L10nupdate.fetch which allows you to trigger an update of the language files. Especially useful for scheduling / upgrading without accessing the UI.