### PR TITLE
Fix #6 - Use GuzzleHttp to retrieve translation files

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -13,10 +13,10 @@
         <author>Nicolas Ganivet (cividesk)</author>
         <email>support@cividesk.com</email>
     </maintainer>
-    <releaseDate>2020-04-05</releaseDate>
-    <version>1.1</version>
+    <releaseDate>2022-07-08</releaseDate>
+    <version>1.2</version>
     <compatibility>
-        <ver>5.19</ver>
+        <ver>5.49</ver>
     </compatibility>
     <comments>
         Once installed, this extension will automatically download translation files for CiviCRM core and extensions when you

--- a/l10nupdate.civix.php
+++ b/l10nupdate.civix.php
@@ -221,7 +221,8 @@ function _l10nupdate_civix_upgrader() {
  * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
@@ -229,32 +230,7 @@ function _l10nupdate_civix_upgrader() {
  * @return array
  */
 function _l10nupdate_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_l10nupdate_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
 
 /**

--- a/l10nupdate.php
+++ b/l10nupdate.php
@@ -141,21 +141,34 @@ function l10nupdate_fetch($locales = '', $forceDownload = FALSE) {
     if (!is_dir($l10n . $locale . $subdir)) {
       $subdir = '';
     }
-    $remoteURL = "https://download.civicrm.org/civicrm-l10n-core/mo/$locale/civicrm.mo";
-    $localFile = $l10n . $locale . $subdir . '/civicrm.mo';
-    if (_l10nupdate_download($remoteURL, $localFile, $forceDownload)) {
-      $downloaded['core']++;
-    }
 
-    // Download extensions translation files
-    foreach (CRM_Core_PseudoConstant::getModuleExtensions() as $module) {
-      $extname = $module['prefix'];
-      $extroot = dirname($module['filePath']);
-      $remoteURL = "https://download.civicrm.org/civicrm-l10n-extensions/mo/$extname/$locale/$extname.mo";
-      $localFile = "$extroot/l10n/$locale/LC_MESSAGES/$extname.mo";
+    try {
+      $remoteURL = "https://download.civicrm.org/civicrm-l10n-core/mo/$locale/civicrm.mo";
+      $localFile = $l10n . $locale . $subdir . '/civicrm.mo';
       if (_l10nupdate_download($remoteURL, $localFile, $forceDownload)) {
-        $downloaded[$extname]++;
+        $downloaded['core']++;
       }
+
+      // Download extensions translation files
+      foreach (CRM_Core_PseudoConstant::getModuleExtensions() as $module) {
+        $extname = $module['prefix'];
+        $extroot = dirname($module['filePath']);
+        $remoteURL = "https://download.civicrm.org/civicrm-l10n-extensions/mo/$extname/$locale/$extname.mo";
+        $localFile = "$extroot/l10n/$locale/LC_MESSAGES/$extname.mo";
+        if (_l10nupdate_download($remoteURL, $localFile, $forceDownload)) {
+          $downloaded[$extname]++;
+        }
+      }
+    }
+    catch (GuzzleHttp\Exception\ConnectException $e) {
+      \Civi::log('l10nupdate')->error("l10nupdate_download Aborting (ConnectException {$remoteURL}): " . $e->getMessage());
+      // Do not try to download any more locales. ConnectException is probably fatal.
+      break;
+    }
+    catch (Exception $e) {
+      \Civi::log('l10nupdate')->error("l10nupdate_download failed: " . $e->getMessage());
+      // Do not try to download any more locales.
+      break;
     }
 
     // Output a nicely formatted message if we have been successful
@@ -188,23 +201,25 @@ function l10nupdate_fetch($locales = '', $forceDownload = FALSE) {
  */
 function _l10nupdate_download($remoteURL, $localFile, $forceDownload = FALSE) {
   $delay = strtotime("1 day");
-  $l10nFileOutOfDate = ((time() - filemtime($localFile)) > $delay);
+  $l10nFileOutOfDate = ((time() - @filemtime($localFile)) > $delay);
 
   if ((!file_exists($localFile)) || $l10nFileOutOfDate || $forceDownload) {
     $localeDir = dirname($localFile);
-    if (!is_dir($localeDir) && !mkdir($localeDir, 0775, true)) {
-      return false;
+    if (!is_dir($localeDir) && !@mkdir($localeDir, 0775, TRUE)) {
+      return FALSE;
     }
-    $result = CRM_Utils_HttpClient::singleton()->fetch($remoteURL, $localFile);
-    if (($result == CRM_Utils_HttpClient::STATUS_OK) && file_exists($localFile)) {
-      // Check if CRM_Utils_HttpClient encountered a HTTP error 404 (cf. CRM-14649)
-      if (strpos(file_get_contents($localFile), '404 Not Found')) {
-        // reset the file to empty (then will not try to reload until delay is passed)
-        fclose(fopen($localFile, 'w'));
-        return false;
-      }
-      return true;
+    $client = new GuzzleHttp\Client();
+    $response = $client->request('GET', $remoteURL, ['sink' => $localFile, 'timeout' => 5, 'http_errors' => FALSE]);
+    if ($response->getStatusCode() !== 200) {
+      \Civi::log()->warning($response->getStatusCode() . ': ' . $response->getReasonPhrase() . ': ' . $remoteURL);
+      // reset the file to empty (then will not try to reload until delay is passed)
+      fclose(fopen($localFile, 'w'));
+      return FALSE;
+    }
+    if (($response->getStatusCode() === 200) && file_exists($localFile)) {
+      return TRUE;
     }
   }
-  return false;
+
+  return FALSE;
 }

--- a/l10nupdate.php
+++ b/l10nupdate.php
@@ -22,7 +22,7 @@ require_once 'l10nupdate.civix.php';
 use CRM_L10nupdate_ExtensionUtil as E;
 
 define('L10N_UPDATE_DOMAIN', 'com.cividesk.l10n.update');
-define('L10N_UPDATE_TSNAME', ts('Localization Update extension', array('domain' => L10N_UPDATE_DOMAIN)));
+define('L10N_UPDATE_TSNAME', E::ts('Localization Update extension'));
 
 /**
  * Implements hook_civicrm_config().
@@ -42,7 +42,7 @@ function l10nupdate_civicrm_buildForm($formName, &$form) {
   // Administer / Localization / Languages, Currency, Locations
   if ($formName == 'CRM_Admin_Form_Setting_Localization') {
     // Replace the drop-down list of locales with all possible locales
-    if ($element = $form->getElement('lcMessages')) {
+    if ($form->getElement('lcMessages')) {
       // Mostly copied from CRM_Admin_Form_Setting_Localization::buildQuickForm()
       $locales = CRM_Contact_BAO_Contact::buildOptions('preferred_language');
       $domain = new CRM_Core_DAO_Domain();
@@ -54,8 +54,8 @@ function l10nupdate_civicrm_buildForm($formName, &$form) {
           $lcMessages[$loc] = $lang;
         }
       }
-      $form->addElement('select', 'lcMessages', ts('Default Language'), $locales);
-      $form->addElement('select', 'addLanguage', ts('Add Language'), array_merge(array('' => ts('- select -')), array_diff($locales, $lcMessages)));
+      $form->addElement('select', 'lcMessages', E::ts('Default Language'), $locales);
+      $form->addElement('select', 'addLanguage', E::ts('Add Language'), array_merge(['' => E::ts('- select -')], array_diff($locales, $lcMessages)));
       // This replaces the uiLanguages select element with one which has all available languages even if they are not already downloaded.
       // If you enable a language this extension will download it.
       $uiLanguagesSetting = \Civi\Core\SettingsMetadata::getMetadata(['name' => ['uiLanguages']], NULL, TRUE)['uiLanguages'];
@@ -77,7 +77,7 @@ function l10nupdate_civicrm_buildForm($formName, &$form) {
  *
  * @throws \CRM_Core_Exception
  */
-function l10nupdate_civicrm_pageRun( &$page ) {
+function l10nupdate_civicrm_pageRun(&$page) {
   // Administer / System Settings / Manage Extensions
   if (is_a($page, 'CRM_Admin_Page_Extensions')) {
     // Refresh localization files
@@ -103,14 +103,14 @@ function l10nupdate_fetch($locales = '', $forceDownload = FALSE) {
   $l10n = CRM_Core_I18n::getResourceDir();
   if (empty($l10n)) {
     CRM_Core_Session::setStatus(
-      ts('Your localization directory is not configured.', array('domain' => L10N_UPDATE_DOMAIN)),
+      E::ts('Your localization directory is not configured.', ['domain' => L10N_UPDATE_DOMAIN]),
       L10N_UPDATE_TSNAME, 'error'
     );
     return;
   }
   if (!is_dir($l10n) || !is_writable($l10n)) {
     CRM_Core_Session::setStatus(
-      ts('Your localization directory, %1, is not writable.', array(1 => $l10n, 'domain' => L10N_UPDATE_DOMAIN)),
+      E::ts('Your localization directory, %1, is not writable.', [1 => $l10n]),
       L10N_UPDATE_TSNAME, 'error'
     );
     return;
@@ -163,12 +163,12 @@ function l10nupdate_fetch($locales = '', $forceDownload = FALSE) {
       $modules = array_keys($downloaded);
       if (sizeof($modules) > 1) {
         $last = array_shift($modules);
-        $list = implode(', ', $modules).' '.ts('and', array('domain' => L10N_UPDATE_DOMAIN)).' '.$last;
+        $list = implode(', ', $modules) . ' ' . E::ts('and') . ' ' . $last;
       } else {
         $list = reset($modules);
       }
       CRM_Core_Session::setStatus(
-        ts('Your localization files for %1 have been updated.', array(1 => $list, 'domain' => L10N_UPDATE_DOMAIN)),
+        E::ts('Your localization files for %1 have been updated.', [1 => $list]),
         L10N_UPDATE_TSNAME, 'success'
       );
     }


### PR DESCRIPTION
GuzzleHttp automatically handles redirects. Core is now using GuzzleHttp instead of `CRM_Utils_HttpClient` - see eg. https://github.com/civicrm/civicrm-core/pull/21097