### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/L10nupdate/Fetch.php
+++ b/api/v3/L10nupdate/Fetch.php
@@ -20,7 +20,7 @@ function _civicrm_api3_l10nupdate_fetch_spec(&$params) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_l10nupdate_fetch($params) {
   $downloaded = l10nupdate_fetch($params['locales'], $params['forceDownload']);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.